### PR TITLE
Enable compilation in 32 bit mode and C++11 features

### DIFF
--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -3,7 +3,8 @@
 cmake_minimum_required(VERSION 2.8)
 
 # default to C99
-set(CMAKE_C_FLAGS "-std=c99" CACHE STRING "")
+set(CMAKE_C_FLAGS "-std=c99 -m32" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "-std=gnu++11 -m32" CACHE STRING "")
 
 # check that we are actually running on Linux, if we're not then we may pull in
 # incorrect dependencies.


### PR DESCRIPTION
32 bit mode compilation is needed for maximum compatibility with
"regular" mbed targets.
