### PR TITLE
Add a linker group to linux builds

### DIFF
--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -6,6 +6,9 @@ cmake_minimum_required(VERSION 2.8)
 set(CMAKE_C_FLAGS "-std=c99" CACHE STRING "")
 set(CMAKE_CXX_FLAGS "-std=gnu++11" CACHE STRING "")
 
+set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_C_COMPILER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> ${GLOBALLY_LINKED_TARGET_LIBS} -lm -lc -lgcc -lm -lc -lgcc -Wl,--end-group -o <TARGET>")
+set(CMAKE_CXX_LINK_EXECUTABLE     "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS>  -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> ${GLOBALLY_LINKED_TARGET_LIBS} -lstdc++ -lsupc++ -lm -lc -lgcc -lstdc++ -lsupc++ -lm -lc -lgcc -Wl,--end-group -o <TARGET>")
+
 # check that we are actually running on Linux, if we're not then we may pull in
 # incorrect dependencies.
 if(NOT (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux"))


### PR DESCRIPTION
This should reduce problems with link order

cc @rgrover 
